### PR TITLE
Title: feat: Implement Slab Cache deallocation and use PhysAddr in Buddy Allocator

### DIFF
--- a/src/kernel/src/kernel.rs
+++ b/src/kernel/src/kernel.rs
@@ -227,22 +227,18 @@ pub extern "C" fn kernel_main(
 	);
 
 	{
-		let mut base = 0;
-		{
+		let base: PhysAddr = {
 			let guard = EARLY_PHYSICAL_ALLOCATOR.lock();
-			let memblock = guard.get().unwrap();
+			let memblock = guard
+				.get()
+				.expect("Failed to get memblock from early allocator");
 
-			let regions = memblock.mem_region();
-			if regions.is_empty() {
-				panic!("Not enough memory space");
-			}
-
-			for region in regions.iter() {
-				if !region.is_empty() {
-					base = region.base().into();
-					break;
-				}
-			}
+			memblock
+				.mem_region()
+				.iter()
+				.find(|&region| !region.is_empty())
+				.map(|region| region.base())
+				.expect("No non-empty memory regions available")
 		};
 
 		#[allow(clippy::implicit_return)]
@@ -264,18 +260,8 @@ pub extern "C" fn kernel_main(
 	Logger::divider();
 	Logger::status("Memory Management", &StatusProgram::OK);
 
-	let test = Box::new("Hallo Wereld");
-	println_serial!("TEST: {}", test);
-	let another_test = Box::new("cool");
-	println_serial!("{}", test);
-	println_serial!("{}", another_test);
-
-	{
-		let test_test = Box::new("abcdef");
-		println_serial!("{}", test);
-		println_serial!("{}", another_test);
-		println_serial!("{}", test_test);
-	}
+	let b = Box::new("Hello world");
+	println_serial!("{}", b);
 
 	let mut keyboard = Keyboard::default();
 	let mut console = Console::default();

--- a/src/kernel/src/memory/allocator.rs
+++ b/src/kernel/src/memory/allocator.rs
@@ -56,9 +56,7 @@ unsafe impl GlobalAlloc for Locked<KernelAllocator> {
 
 		match index {
 			Some(index) => {
-				println_serial!("Locking Slab Cache");
 				let mut allocator = SLAB_CACHES.lock();
-				println_serial!("Locked Slab Cache");
 
 				match allocator.get_mut() {
 					Some(caches) => {


### PR DESCRIPTION
This PR introduces several key improvements and features related to memory management:

1.  **Slab Cache Deallocation:**
    * Implements the `SlabCache::dealloc` method.
    * Given a pointer, it correctly identifies the corresponding slab.
    * Adds the deallocated object back to the slab's internal free list.
    * Manages the slab's state by moving it between the `slabs_full`, `slabs_partial`, and `slabs_free` lists as objects are deallocated (using the new `remove` method). Currently, empty slabs are added to the `slabs_free` list.

2.  **Intrusive Linked List Remove:**
    * Adds `IntrusiveLinkedList::remove` (wrapping `remove_node`) to allow removing arbitrary nodes from the list.
    * This is used by `SlabCache::dealloc` to manage the slab lists efficiently.

3.  **Buddy Allocator Type Safety:**
    * Refactors the `BuddyAllocator` to use `PhysAddr` instead of raw `usize` for tracking base addresses and free list entries.
    * This improves type safety and clarity when dealing with physical addresses within the allocator.

4.  **Refactoring & Cleanup:**
    * Refactors the code in `kernel_main` to find the first available physical memory region base address using a more concise iterator-based approach (`find().map().expect()`).
    * Removes miscellaneous test code (`Box::new`) and debug `println_serial!` statements from `kernel.rs`, `allocator.rs`.

This PR significantly advances the kernel's memory management capabilities by enabling slab deallocation and improving the robustness of the buddy allocator.