### PR TITLE
feat(mm): Implement virtual memory management and paging

### DIFF
--- a/src/arch/x86/x86.ld
+++ b/src/arch/x86/x86.ld
@@ -20,6 +20,7 @@ SECTIONS {
 
   /* Start at 2MB */
 	. = 0x2M;
+  _kernel_physical_start = .;
 
   .multiboot ALIGN(4K) : {
     KEEP(*(.multiboot))

--- a/src/kernel/src/arch/x86/cpu/control.rs
+++ b/src/kernel/src/arch/x86/cpu/control.rs
@@ -1,4 +1,5 @@
-use core::arch::asm;
+use crate::memory::{PhysAddr, VirtAddr};
+use core::{arch::asm, option};
 
 #[inline]
 #[doc(hidden)]
@@ -21,5 +22,37 @@ pub fn halt() {
 pub fn halt_loop() -> ! {
 	loop {
 		halt();
+	}
+}
+
+#[inline]
+#[doc(hidden)]
+pub fn cr3() -> PhysAddr {
+	let cr3: usize;
+
+	unsafe {
+		asm!("mov {}, cr3", out(reg) cr3, options(nomem, nostack, preserves_flags))
+	};
+
+	PhysAddr::new(cr3)
+}
+
+#[inline]
+#[doc(hidden)]
+pub fn cr2() -> VirtAddr {
+	let cr2: usize;
+
+	unsafe {
+		asm!("mov {}, cr2", out(reg) cr2, options(nomem, nostack, preserves_flags))
+	};
+
+	VirtAddr::new(cr2)
+}
+
+#[inline(always)]
+#[doc(hidden)]
+pub fn invlpg(addr: VirtAddr) {
+	unsafe {
+		asm!("invlpg [{}]", in(reg) addr.as_usize(), options(nostack, preserves_flags));
 	}
 }

--- a/src/kernel/src/collections/intrusive_linked_list.rs
+++ b/src/kernel/src/collections/intrusive_linked_list.rs
@@ -1,6 +1,7 @@
 //! Defines an intrusive doubly linked list implementation.
 //! Nodes (`IntrusiveNode`) are embedded within the structs they link (`T`).
 
+use crate::println_serial;
 use core::{
 	marker::PhantomData,
 	ptr::{self, NonNull},
@@ -89,6 +90,13 @@ impl<T: ?Sized> IntrusiveLinkedList<T> {
 	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		self.head.is_none()
+	}
+
+	/// Returns the length of the list
+	#[inline]
+	#[must_use]
+	pub fn len(&self) -> usize {
+		self.len
 	}
 
 	/// Removes the specified node from the list (safe wrapper).
@@ -207,6 +215,11 @@ impl<T: ?Sized> IntrusiveLinkedList<T> {
 		}
 
 		self.len -= 1;
+
+		if self.len == 0 {
+			self.head = None;
+			self.tail = None;
+		}
 
 		node.prev = None;
 		node.next = None;

--- a/src/kernel/src/kernel.rs
+++ b/src/kernel/src/kernel.rs
@@ -64,11 +64,12 @@ pub mod tests;
 /// TTY Support - Specifically VGA
 pub mod tty;
 
+use alloc::boxed::Box;
 use arch::x86::multiboot::MultibootInfo;
 use core::ffi::c_void;
 use device::keyboard::Keyboard;
 use libc::console::console::Console;
-use memory::allocator::memory_init;
+use memory::{allocator::memory_init, frame::FRAME_ALLOCATOR, FrameAllocator};
 use tty::serial::SERIAL;
 
 extern crate alloc;
@@ -104,6 +105,11 @@ pub extern "C" fn kernel_main(
 
 	#[cfg(test)]
 	test_main();
+
+	let test1 = Box::new("Test 1");
+	let test2 = Box::new(10);
+
+	println_serial!("{} - {}", test1, test2);
 
 	loop {
 		let c = match keyboard.input() {

--- a/src/kernel/src/memory/addr.rs
+++ b/src/kernel/src/memory/addr.rs
@@ -269,7 +269,7 @@ impl VirtAddr {
 	/// See the `align_down` function for more information.
 	#[inline]
 	pub(crate) const fn align_down_usize(self, align: usize) -> Self {
-		VirtAddr::new_truncate(align_down(self.0, align))
+		VirtAddr(align_down(self.0, align))
 	}
 
 	/// Checks whether the virtual address has the demanded alignment.

--- a/src/kernel/src/memory/frame.rs
+++ b/src/kernel/src/memory/frame.rs
@@ -1,0 +1,155 @@
+use super::{
+	allocator::EARLY_PHYSICAL_ALLOCATOR, get_kernel_physical_end,
+	get_kernel_physical_start, MemorySegment, PhysAddr, KERNEL_OFFSET,
+	PAGE_SIZE,
+};
+use crate::{log_warn, sync::Mutex};
+use core::{
+	cell::OnceCell,
+	sync::atomic::{AtomicUsize, Ordering},
+	usize,
+};
+
+const TOTAL_FRAMES: usize = usize::MAX / PAGE_SIZE + 1;
+const BITMAP_ENTRY_SIZE_BITS: usize = u64::BITS as usize;
+const BITMAP_ARRAY_SIZE: usize =
+	(TOTAL_FRAMES + BITMAP_ENTRY_SIZE_BITS - 1) / BITMAP_ENTRY_SIZE_BITS;
+
+pub static FRAME_ALLOCATOR: Mutex<OnceCell<FrameAllocator>> =
+	Mutex::new(OnceCell::new());
+
+static FRAME_BITMAP: Mutex<[u64; BITMAP_ARRAY_SIZE]> =
+	Mutex::new([u64::MAX; BITMAP_ARRAY_SIZE]);
+
+pub struct FrameAllocator {
+	next_free_idx: AtomicUsize,
+}
+
+impl FrameAllocator {
+	pub const fn new() -> Self {
+		Self {
+			next_free_idx: AtomicUsize::new(0),
+		}
+	}
+
+	/// Initializes the static frame bitmap based on the memory map.
+	/// Marks known used areas like the kernel and the bitmap itself.
+	/// MUST be called only once during kernel initialization.
+	pub fn init(&self) {
+		let mut bitmap = FRAME_BITMAP.lock();
+		let guard = EARLY_PHYSICAL_ALLOCATOR.lock();
+		let regions = guard
+			.get()
+			.expect("Memblock has not been initialized")
+			.mem_region();
+
+		for region in regions.iter() {
+			let start_addr = region.base();
+			let end_addr = start_addr + region.size();
+
+			let first_frame_idx =
+				(start_addr.as_usize() + PAGE_SIZE - 1) / PAGE_SIZE;
+			let last_frame_idx = end_addr.as_usize() / PAGE_SIZE;
+
+			for frame_idx in first_frame_idx..last_frame_idx {
+				if frame_idx < TOTAL_FRAMES {
+					let entry_idx = frame_idx / BITMAP_ENTRY_SIZE_BITS;
+					let bit_idx = frame_idx % BITMAP_ENTRY_SIZE_BITS;
+					bitmap[entry_idx] &= !(1 << bit_idx);
+				}
+			}
+		}
+
+		let kernel_start_frame =
+			get_kernel_physical_start().as_usize() / PAGE_SIZE;
+		let kernel_end_frame =
+			(get_kernel_physical_end().as_usize() + PAGE_SIZE - 1) / PAGE_SIZE;
+		self.mark_range_used(&mut bitmap, kernel_start_frame, kernel_end_frame);
+
+		let bitmap_virt_addr = bitmap.as_ptr() as usize;
+		let bitmap_phys_addr = bitmap_virt_addr
+			.checked_sub(KERNEL_OFFSET)
+			.expect("Failed to calculate bitmap physical address");
+		let bitmap_size_bytes = BITMAP_ARRAY_SIZE * size_of::<u64>();
+
+		let bitmap_start_frame = bitmap_phys_addr / PAGE_SIZE;
+		let bitmap_end_frame =
+			(bitmap_phys_addr + bitmap_size_bytes + PAGE_SIZE - 1) / PAGE_SIZE;
+		self.mark_range_used(&mut bitmap, bitmap_start_frame, bitmap_end_frame);
+	}
+
+	/// Allocates a single physical frame.
+	pub fn allocate_frame(&self) -> Option<PhysAddr> {
+		let mut bitmap = FRAME_BITMAP.lock();
+		let start_idx = self.next_free_idx.load(Ordering::Relaxed);
+
+		for entry_idx in start_idx..BITMAP_ARRAY_SIZE {
+			if bitmap[entry_idx] != u64::MAX {
+				for bit_idx in 0..BITMAP_ENTRY_SIZE_BITS {
+					let mask = 1 << bit_idx;
+					if (bitmap[entry_idx] & mask) == 0 {
+						let frame_idx =
+							entry_idx * BITMAP_ENTRY_SIZE_BITS + bit_idx;
+
+						if frame_idx >= TOTAL_FRAMES {
+							continue;
+						}
+
+						bitmap[entry_idx] |= mask;
+
+						self.next_free_idx.store(entry_idx, Ordering::Relaxed);
+
+						return Some(PhysAddr::new(frame_idx * PAGE_SIZE));
+					}
+				}
+			}
+		}
+
+		None
+	}
+
+	/// Deallocates a single physical frame.
+	pub fn deallocate_frame(&self, frame: PhysAddr) {
+		let frame_idx = frame.as_usize() / PAGE_SIZE;
+		if frame_idx >= TOTAL_FRAMES {
+			log_warn!(
+				"Attempted to deallocate frame outside tracked range: {:?}",
+				frame
+			);
+			return;
+		}
+
+		let entry_idx = frame_idx / BITMAP_ENTRY_SIZE_BITS;
+		let bit_idx = frame_idx % BITMAP_ENTRY_SIZE_BITS;
+		let mask = 1 << bit_idx;
+
+		let mut bitmap = FRAME_BITMAP.lock();
+
+		if (bitmap[entry_idx] & mask) == 0 {
+			log_warn!("Double free detected for frame: {:?}", frame);
+			return;
+		}
+
+		bitmap[entry_idx] &= !mask;
+
+		if entry_idx < self.next_free_idx.load(Ordering::Relaxed) {
+			self.next_free_idx.store(entry_idx, Ordering::Relaxed);
+		}
+	}
+
+	// Helper to mark a range as used (sets bits)
+	fn mark_range_used(
+		&self,
+		bitmap: &mut [u64; BITMAP_ARRAY_SIZE],
+		start_frame: usize,
+		end_frame: usize,
+	) {
+		for frame_idx in start_frame..end_frame {
+			if frame_idx < TOTAL_FRAMES {
+				let entry_idx = frame_idx / BITMAP_ENTRY_SIZE_BITS;
+				let bit_idx = frame_idx % BITMAP_ENTRY_SIZE_BITS;
+				bitmap[entry_idx] |= 1 << bit_idx;
+			}
+		}
+	}
+}

--- a/src/kernel/src/memory/memblock.rs
+++ b/src/kernel/src/memory/memblock.rs
@@ -29,51 +29,34 @@ pub struct MemRegion {
 
 impl MemRegion {
 	/// Creates a new memory region with the specified base address and size.
-	///
-	/// # Parameters
-	/// * `base` - The starting physical address of the memory region
-	/// * `size` - The size of the memory region in bytes
-	///
-	/// # Returns
-	/// A new `MemRegion` instance representing the specified memory area
 	pub const fn new(base: PhysAddr, size: usize) -> Self {
-		return Self {
+		Self {
 			base,
 			size,
-		};
+		}
 	}
 
 	/// Checks if this memory region is empty (has zero size).
-	///
-	/// An empty region represents an unused slot in the memory region arrays.
-	///
-	/// # Returns
-	/// `true` if the region is empty, `false` otherwise
 	pub fn is_empty(&self) -> bool {
-		return *self == MemRegion::empty();
+		*self == MemRegion::empty()
 	}
 
 	/// Creates an empty memory region with zero base address and size.
-	///
-	/// Used to initialize memory region arrays and to represent unused slots.
-	///
-	/// # Returns
-	/// An empty `MemRegion` instance
 	pub const fn empty() -> Self {
-		return MemRegion {
+		MemRegion {
 			base: PhysAddr::new(0x0),
 			size: 0,
-		};
+		}
 	}
 
 	/// Returns the base of region
 	pub const fn base(&self) -> PhysAddr {
-		return self.base;
+		self.base
 	}
 
 	/// Returns size of region
 	pub const fn size(&self) -> usize {
-		return self.size;
+		self.size
 	}
 }
 
@@ -94,19 +77,16 @@ impl MemBlockAllocator {
 	///
 	/// Initializes the allocator with zero available and zero reserved memory
 	/// regions. This is typically called very early in the boot process.
-	///
-	/// # Returns
-	/// A new empty `MemBlockAllocator` instance
 	#[allow(clippy::new_without_default)]
 	pub const fn new() -> Self {
 		const EMPTY: MemRegion = MemRegion::empty();
 
-		return Self {
+		Self {
 			memory_region: [EMPTY; MAX_REGION],
 			reserved_region: [EMPTY; MAX_REGION],
 			memory_count: 0,
 			reserved_count: 0,
-		};
+		}
 	}
 
 	/// Creates a new memory block allocator with empty region arrays.
@@ -121,7 +101,7 @@ impl MemBlockAllocator {
 			#[allow(clippy::single_match)]
 			match segment.segment_type() {
 				RegionType::Available => {
-					if !self.add(segment.start_addr().into(), segment.size()) {
+					if !self.add(segment.start_addr(), segment.size()) {
 						panic!("memblock: MAX_COUNT is full in memory segment");
 					}
 				}
@@ -132,22 +112,22 @@ impl MemBlockAllocator {
 
 	/// Returns a reference of the current length of `mem_region`
 	pub const fn mem_count(&self) -> usize {
-		return self.memory_count;
+		self.memory_count
 	}
 
 	/// Returns a reference to the current `memregion`
 	pub const fn mem_region(&self) -> &[MemRegion; MAX_REGION] {
-		return &self.memory_region;
+		&self.memory_region
 	}
 
 	/// Returns a reference of the current length of `reserved_region`
 	pub const fn reserved_count(&self) -> usize {
-		return self.reserved_count;
+		self.reserved_count
 	}
 
 	/// Returns a reference to the current `reserved_region`
 	pub const fn reserved_region(&self) -> &[MemRegion; MAX_REGION] {
-		return &self.reserved_region;
+		&self.reserved_region
 	}
 
 	/// Allocates memory with the specified layout requirements.
@@ -167,10 +147,8 @@ impl MemBlockAllocator {
 	/// A pointer to the allocated memory or null if allocation fails
 	pub unsafe fn alloc(&mut self, layout: Layout) -> *mut u8 {
 		match self.find_free_region(layout.size(), layout.align()) {
-			Some(addr) => {
-				return ptr::with_exposed_provenance_mut(addr.as_usize())
-			}
-			None => return ptr::null_mut(),
+			Some(addr) => addr.as_mut_ptr(),
+			None => ptr::null_mut(),
 		}
 	}
 
@@ -187,30 +165,6 @@ impl MemBlockAllocator {
 	/// This function always panics if called
 	pub unsafe fn dealloc(&mut self, _ptr: *mut u8, _layout: Layout) {
 		panic!("memblock::dealloc: Should never been called");
-	}
-
-	fn sort_regions(&mut self, region_type: RegionType) {
-		let (regions, count) = match region_type {
-			RegionType::Available => {
-				(&mut self.memory_region, self.memory_count)
-			}
-			RegionType::Reserved => {
-				(&mut self.reserved_region, self.reserved_count)
-			}
-			_ => (&mut self.memory_region, self.memory_count),
-		};
-
-		for i in 1..count {
-			let key = regions[i];
-			let mut j = i;
-
-			while j > 0 && regions[j - 1].base > key.base {
-				regions[j] = regions[j - 1];
-				j -= 1;
-			}
-
-			regions[j] = key;
-		}
 	}
 
 	fn remove(&mut self, region_type: RegionType, index: usize) {
@@ -352,6 +306,6 @@ impl MemBlockAllocator {
 			return Some(aligned_addr);
 		}
 
-		return None;
+		None
 	}
 }

--- a/src/kernel/src/memory/mod.rs
+++ b/src/kernel/src/memory/mod.rs
@@ -11,6 +11,7 @@ extern crate alloc;
 pub mod addr;
 pub mod allocator;
 pub mod buddy;
+pub mod frame;
 pub mod memblock;
 pub mod node_pool;
 pub mod paging;
@@ -18,13 +19,39 @@ pub mod slab;
 
 pub use addr::{PhysAddr, VirtAddr};
 pub use buddy::BuddyAllocator;
+use core::sync::atomic::{AtomicUsize, Ordering};
+pub use frame::FrameAllocator;
 pub use memblock::MemBlockAllocator;
 pub use node_pool::NodePoolAllocator;
-pub use paging::Mapper;
 pub use slab::SlabCache;
 
 /* -------------------------------------- */
 
+extern "C" {
+	static _kernel_virtual_end: u8;
+	static _kernel_physical_start: u8;
+	static _kernel_physical_end: u8;
+}
+
+/// Function to get the physical start address of the kernel image.
+pub fn get_kernel_physical_start() -> PhysAddr {
+	unsafe { PhysAddr::new(&_kernel_physical_start as *const u8 as usize) }
+}
+
+/// Function to get the physical end address of the kernel image.
+pub fn get_kernel_physical_end() -> PhysAddr {
+	unsafe { PhysAddr::new(&_kernel_physical_end as *const u8 as usize) }
+}
+
+/// Function to get the virtual end address of the kernel image.
+pub fn get_kernel_virtual_end() -> VirtAddr {
+	unsafe { VirtAddr::new(&_kernel_virtual_end as *const u8 as usize) }
+}
+
+/* -------------------------------------- */
+
+/// The offset of the kernel
+const KERNEL_OFFSET: usize = 0xc0000000;
 /// Defines the system's page size
 pub const PAGE_SIZE: usize = 4096;
 
@@ -40,11 +67,39 @@ pub enum RegionType {
 	BadMemory = 5,
 }
 
+/* -------------------------------------- */
+
+const NODE_POOL_VIRT_START: usize = 0xc1000000;
+
+const VIRT_START: usize = 0xd000_0000;
+const VIRT_SIZE: usize = 1024 * 1024 * 128;
+const VIRT_END: usize = VIRT_START + VIRT_SIZE;
+
+static NEXT_FREE_VIRT_ADDR: AtomicUsize = AtomicUsize::new(VIRT_START);
+
+/// Function to allocate a contiguous block of virtual address space
+/// Returns the start virtual address of the allocated block, or None if out of
+/// space.
+pub fn allocate_dynamic_virt_range(size: usize) -> Option<VirtAddr> {
+	let size = (size + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
+	let current_start = NEXT_FREE_VIRT_ADDR.fetch_add(size, Ordering::SeqCst);
+	let allocation_end = current_start.checked_add(size)?;
+
+	if allocation_end > VIRT_END {
+		NEXT_FREE_VIRT_ADDR.fetch_sub(size, Ordering::SeqCst);
+		return None;
+	}
+
+	Some(VirtAddr::new(current_start))
+}
+
+/* -------------------------------------- */
+
 /// Represents a segment of memory in the system's memory map.
 /// Each segment has a start address, size, and type that indicates its usage.
 #[derive(Debug, Copy, Clone)]
 pub struct MemorySegment {
-	start_addr: usize,
+	start_addr: PhysAddr,
 	len: usize,
 	segment_type: RegionType,
 }
@@ -57,40 +112,40 @@ impl MemorySegment {
 	/// * `size` - The size of the memory segment in bytes
 	/// * `segment_type` - The type of memory segment (Available, Reserved, etc)
 	pub fn new(
-		start_addr: usize,
+		start_addr: PhysAddr,
 		len: usize,
 		segment_type: RegionType,
 	) -> Self {
-		return Self {
+		Self {
 			start_addr,
 			len,
 			segment_type,
-		};
+		}
 	}
 
 	/// Creates an empty memory segment with zero base address, size, and
 	/// `Unknown` type. Useful for initializing arrays or representing
 	/// invalid/unused segments.
 	pub const fn empty() -> Self {
-		return Self {
-			start_addr: 0,
+		Self {
+			start_addr: PhysAddr::new(0),
 			len: 0,
 			segment_type: RegionType::Unknown,
-		};
+		}
 	}
 
 	/// Returns the physical start address of this memory segment
-	pub const fn start_addr(&self) -> usize {
-		return self.start_addr;
+	pub const fn start_addr(&self) -> PhysAddr {
+		self.start_addr
 	}
 
 	/// Returns the size of this memory segment in bytes
 	pub const fn size(&self) -> usize {
-		return self.len;
+		self.len
 	}
 
 	/// Returns the type of this memory segment (Available, Reserved, etc)
 	pub const fn segment_type(&self) -> RegionType {
-		return self.segment_type;
+		self.segment_type
 	}
 }

--- a/src/kernel/src/memory/paging.rs
+++ b/src/kernel/src/memory/paging.rs
@@ -1,27 +1,206 @@
-use super::{PhysAddr, VirtAddr};
+use super::{FrameAllocator, PhysAddr, VirtAddr, KERNEL_OFFSET};
+use crate::{
+	arch::x86::cpu::{cr3, invlpg},
+	log_debug,
+	memory::{frame::FRAME_ALLOCATOR, PAGE_SIZE},
+	println_serial,
+};
+use core::arch::asm;
 
-pub struct Mapper;
+const PAGE_SIZE_4MIB: usize = 4 * 1024 * 1024;
 
-// Public Interface
-impl Mapper {
-	#[inline]
-	#[must_use]
-	pub fn map(virt_addr: VirtAddr) {
-		!unimplemented!()
+const PDE_PRESENT: u32 = 1 << 0;
+const PDE_WRITABLE: u32 = 1 << 1;
+const PDE_USER: u32 = 1 << 2;
+const PDE_PSE: u32 = 1 << 7;
+
+const ADDR_MASK_4KIB_PTE: u32 = 0xfffff000;
+const ADDR_MASK_4MIB_PDE: u32 = 0xffc00000;
+const ADDR_MASK_PDE_TO_PT: u32 = 0xfffff000;
+
+pub mod flags {
+	pub const PRESENT: u32 = 1 << 0;
+	pub const WRITABLE: u32 = 1 << 1;
+	pub const USER_ACCESSIBLE: u32 = 1 << 2;
+	pub const PAGE_SIZE_EXT: u32 = 1 << 7;
+}
+
+#[inline]
+#[allow(clippy::expect_used)]
+pub fn map_page(phys_addr: PhysAddr, virt_addr: VirtAddr, flags: u32) {
+	use core::ptr;
+
+	assert!(phys_addr.is_aligned(PAGE_SIZE));
+	assert!(virt_addr.is_aligned(PAGE_SIZE));
+
+	let vaddr = virt_addr.as_usize();
+	let paddr = phys_addr.as_usize();
+
+	let pd_paddr = cr3();
+	let pd_vaddr = phys_to_virt(pd_paddr);
+
+	let page_directory: &mut [u32; 1024] =
+		unsafe { &mut *(pd_vaddr.as_mut_ptr()) };
+	let pde_ref = &mut page_directory[vaddr >> 22];
+
+	let pt_phys_addr: PhysAddr;
+	if (*pde_ref & flags::PRESENT) == 0 {
+		let new_pt_frame = FRAME_ALLOCATOR
+            .lock()
+            .get()
+            .expect("Frame has not been initialized yet")
+            .allocate_frame()
+            .expect("Allocation Failed: Could not allocate frame for new page table");
+
+		pt_phys_addr = new_pt_frame;
+		let new_pt_virt_addr = phys_to_virt(new_pt_frame);
+
+		let new_page_table: &mut [u32; 1024] =
+			unsafe { &mut *(new_pt_virt_addr.as_mut_ptr()) };
+		new_page_table.iter_mut().for_each(|entry| *entry = 0);
+
+		*pde_ref =
+			(new_pt_frame.as_usize() as u32) | flags::PRESENT | flags::WRITABLE; // Set PRESENT and WRITABLE for the PDE
+	} else if (*pde_ref & flags::PAGE_SIZE_EXT) != 0 {
+		panic!(
+			"Conflict: Tried to map 4KiB page into a 4MiB mapped region: {:#x}",
+			virt_addr.as_usize()
+		);
+	} else {
+		pt_phys_addr = PhysAddr::new((*pde_ref & ADDR_MASK_PDE_TO_PT) as usize);
 	}
 
-	#[inline]
-	#[must_use]
-	pub fn unmap(virt_addr: VirtAddr) {
-		!unimplemented!()
+	let pt_virt_addr = phys_to_virt(pt_phys_addr);
+	let page_table: &mut [u32; 1024] =
+		unsafe { &mut *(pt_virt_addr.as_mut_ptr()) };
+
+	let pte_ref = &mut page_table[(vaddr >> 12) & 0x3ff];
+
+	*pte_ref = (paddr as u32) | (flags & 0xfff) | flags::PRESENT;
+
+	invlpg(virt_addr);
+}
+
+#[inline]
+pub fn unmap_page(virt_addr: VirtAddr) {
+	use core::ptr;
+
+	assert!(virt_addr.is_aligned(PAGE_SIZE));
+
+	let pd_paddr = cr3();
+	let pd_vaddr = phys_to_virt(pd_paddr);
+
+	let page_directory: &mut [u32; 1024] =
+		unsafe { &mut *(pd_vaddr.as_mut_ptr()) };
+
+	let pde_index = virt_addr.as_usize() >> 22;
+	let pde_ref = &mut page_directory[pde_index];
+
+	if (*pde_ref & flags::PRESENT) == 0 {
+		panic!("Attempted to unmap unmapped virtual address (PDE not present): {:#x}", virt_addr.as_usize());
 	}
 
-	#[inline]
-	#[must_use]
-	pub fn translate(virt_addr: VirtAddr) -> Option<PhysAddr> {
-		!unimplemented!()
+	if (*pde_ref & flags::PAGE_SIZE_EXT) != 0 {
+		panic!(
+			"Attempted to unmap 4MiB page using 4KiB unmap function: {:#x}",
+			virt_addr.as_usize()
+		);
+	}
+
+	let pt_phys_addr = PhysAddr::new((*pde_ref & ADDR_MASK_PDE_TO_PT) as usize);
+	let pt_virt_addr = phys_to_virt(pt_phys_addr);
+
+	let page_table: &mut [u32; 1024] =
+		unsafe { &mut *(pt_virt_addr.as_mut_ptr()) };
+
+	let pte_index = (virt_addr.as_usize() >> 12) & 0x3ff;
+	let pte_ref = &mut page_table[pte_index];
+	let pte = *pte_ref;
+
+	if (pte & flags::PRESENT) == 0 {
+		panic!("Attempted to unmap unmapped virtual address (PTE not present): {:#x}", virt_addr.as_usize());
+	}
+
+	let mapped_frame_phys_addr =
+		PhysAddr::new((pte & ADDR_MASK_4KIB_PTE) as usize);
+
+	*pte_ref = 0;
+
+	invlpg(virt_addr);
+
+	FRAME_ALLOCATOR
+		.lock()
+		.get()
+		.expect("Frame has not been initialized yet")
+		.deallocate_frame(mapped_frame_phys_addr);
+
+	let mut page_table_is_empty = true;
+	for i in 0..1024 {
+		if (page_table[i] & flags::PRESENT) != 0 {
+			page_table_is_empty = false;
+			break;
+		}
+	}
+
+	if page_table_is_empty {
+		FRAME_ALLOCATOR
+			.lock()
+			.get()
+			.expect("Frame allocator not initialized for PT deallocation")
+			.deallocate_frame(pt_phys_addr);
+
+		*pde_ref = 0;
 	}
 }
 
-// Private Interface
-impl Mapper {}
+#[inline]
+#[must_use]
+pub fn translate(virt_addr: VirtAddr) -> Option<PhysAddr> {
+	use core::ptr;
+
+	let paddr = cr3();
+	let pd_virt_addr = phys_to_virt(paddr);
+	let page_directory = unsafe { &*(pd_virt_addr.as_ptr()) as &[u32; 1024] };
+	let pde = page_directory[virt_addr.as_usize() >> 22];
+
+	if (pde & flags::PRESENT) == 0 {
+		return None;
+	}
+
+	if (pde & flags::PAGE_SIZE_EXT) != 0 {
+		let page_base_phys = (pde & ADDR_MASK_4MIB_PDE) as usize;
+		let offset_in_page = virt_addr.as_usize() & (PAGE_SIZE_4MIB - 1);
+
+		log_debug!(
+			"4MiB page mapping: VA {:#x} -> PA {:#x}",
+			virt_addr.as_usize(),
+			page_base_phys + offset_in_page
+		);
+		return Some(PhysAddr::new(page_base_phys + offset_in_page));
+	}
+
+	let pt_phys_addr = PhysAddr::new((pde & ADDR_MASK_PDE_TO_PT) as usize);
+	let pt_virt_addr = phys_to_virt(pt_phys_addr);
+
+	let page_table =
+		unsafe { &*((pt_virt_addr.as_ptr()) as *const [u32; 1024]) };
+	let pte = page_table[(virt_addr.as_usize() >> 12) & 0x3ff];
+
+	if (pte & flags::PRESENT) == 0 {
+		return None;
+	}
+
+	let frame_phys_addr = (pte & ADDR_MASK_4KIB_PTE) as usize;
+	let offset_in_page = virt_addr.as_usize() & (PAGE_SIZE - 1);
+
+	log_debug!(
+		"4KiB page mapping: VA {:#x} -> PA {:#x}",
+		virt_addr.as_usize(),
+		frame_phys_addr + offset_in_page
+	);
+	Some(PhysAddr::new(frame_phys_addr + offset_in_page))
+}
+
+pub fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+	VirtAddr::new(paddr.as_usize() + KERNEL_OFFSET)
+}

--- a/src/kernel/src/panic.rs
+++ b/src/kernel/src/panic.rs
@@ -6,6 +6,7 @@ use core::panic::PanicInfo;
 fn panic(info: &PanicInfo) -> ! {
 	with_fg_color!(VgaColour::Red, {
 		println!("{}", info);
+		println_serial!("{}", info);
 	});
 
 	loop {}

--- a/src/kernel/src/tests/unit/mm_tests.rs
+++ b/src/kernel/src/tests/unit/mm_tests.rs
@@ -1,0 +1,56 @@
+use crate::{log_debug, memory::paging::translate, println_serial};
+use alloc::{boxed::Box, vec};
+
+#[test_case]
+fn test_translate_1() {
+	assert_eq!(translate(0xc0000000.into()).unwrap().as_usize(), 0x0);
+}
+
+#[test_case]
+fn test_translate_2() {
+	assert_eq!(translate(0xc0400000.into()).unwrap().as_usize(), 0x00400000);
+}
+
+#[test_case]
+fn test_translate_3() {
+	assert_eq!(translate(0xd0000000.into()), None);
+}
+
+#[test_case]
+fn test_global_allocator_simple() {
+	log_debug!("ONE!");
+	let x = Box::new(42);
+	assert_eq!(*x, 42);
+
+	log_debug!("TWO!");
+	let y = Box::new(42);
+	assert_eq!(*y, 42);
+
+	log_debug!("THREE!");
+	let mut vec = vec![1, 2, 3];
+	assert_eq!(vec.len(), 3);
+	log_debug!("FOUR!");
+
+	vec.push(4);
+	assert_eq!(vec.len(), 4);
+	log_debug!("FIVE!");
+}
+
+#[test_case]
+fn test_global_allocator_many_boxes() {
+	for i in 0..1000 {
+		let x = Box::new(i);
+		assert_eq!(*x, i);
+	}
+}
+
+#[test_case]
+fn test_global_allocator_large_vec() {
+	let mut vec = vec![0usize; 250];
+	for (i, v) in vec.iter_mut().enumerate() {
+		*v = i;
+	}
+	for (i, v) in vec.iter().enumerate() {
+		assert_eq!(v, &i);
+	}
+}

--- a/src/kernel/src/tests/unit/mod.rs
+++ b/src/kernel/src/tests/unit/mod.rs
@@ -2,5 +2,6 @@
 /* -------------------------------------- */
 pub mod gdt_tests;
 pub mod linked_list_tests;
+pub mod mm_tests;
 pub mod tty_tests;
 // pub mod pic_tests;

--- a/src/kernel/src/tty/log.rs
+++ b/src/kernel/src/tty/log.rs
@@ -29,6 +29,15 @@ pub fn _log(
 		LogLevel::Debug => ("[DEBUG]", VgaColour::LightGreen),
 	};
 
+	if LogLevel::Debug == level {
+		println_serial!(
+			"[{}] {} {}",
+			format_args!("{}", module),
+			level_str,
+			args
+		);
+	}
+
 	with_fg_color!(color, {
 		println!("[{}] {} {}", format_args!("{}", module), level_str, args);
 	});


### PR DESCRIPTION
This pull request introduces a comprehensive virtual memory management system, a foundational feature for the kernel. It replaces the previous physical-only memory allocators with a complete paging-enabled infrastructure, including a physical frame allocator, a paging implementation, and a virtual-memory-aware heap.

### Key Changes:

* **Physical Frame Allocator (`memory/frame.rs`)**
    * A new bitmap-based `FrameAllocator` is introduced to manage the physical memory frames (pages) of the system.
    * It initializes by parsing the bootloader's memory map, marking the kernel's own memory and the bitmap itself as reserved.
    * Provides `allocate_frame()` and `deallocate_frame()` for the rest of the memory manager.

* **Paging Implementation (`memory/paging.rs`)**
    * The paging module has been completely implemented.
    * `map_page()`: Maps a given physical frame to a virtual page. It can automatically allocate and create new page tables on demand using the `FrameAllocator`.
    * `unmap_page()`: Unmaps a virtual page, frees the corresponding physical frame, and deallocates the page table if it becomes empty.
    * `translate()`: Translates a virtual address to its corresponding physical address, supporting both 4KiB and 4MiB pages.

* **VM-Aware Heap (Slab & Buddy Allocators)**
    * The `SlabCache` and `BuddyAllocator` have been refactored to operate on virtual addresses.
    * When a new slab is required, the `SlabCache` now:
        1.  Requests a contiguous virtual address range from a new dynamic VA space allocator.
        2.  Allocates physical frames from the `BuddyAllocator` (which in turn uses the `FrameAllocator`).
        3.  Maps the allocated physical frames to the virtual address range using `map_page`.
    * This enables the global allocator to provide memory from a virtual address space, making `Box`, `Vec`, and other collections fully functional.

* **Improved Exception Handling & Debugging**
    * The Page Fault (`#PF`) handler now reads the `cr2` register to report the faulting address and provides a more detailed analysis of the error code.
    * Extensive serial logging (`println_serial!`) has been added throughout the memory management subsystem to aid in debugging. Panics and debug logs are now reliably sent to the serial port.

* **Testing & Bug Fixes**
    * A new test suite (`mm_tests.rs`) has been added to validate the memory management system, including address translation and heap allocations (`Box`, `Vec`).
    * Fixed a critical bug in `IntrusiveLinkedList` where `head`/`tail` were not being cleared when the list became empty.
    * Improved type safety by consistently using `PhysAddr` and `VirtAddr` wrappers instead of raw `usize`.

This PR lays the groundwork for all future memory-related features, including user-space processes and more complex memory mapping scenarios.